### PR TITLE
Update `LoraModule.at_send` to wait for an exit condition

### DIFF
--- a/05-lora-tillo/code.py
+++ b/05-lora-tillo/code.py
@@ -2,7 +2,6 @@ import board
 import busio
 import e5
 
-mode = "OTAA"
 appkey = "your appkey"
 appeui = "your appeiu"
 
@@ -12,6 +11,6 @@ uart = busio.UART(board.GP4, board.GP5, baudrate=9600)
 lora_module = e5.LoRaModule(uart)
 
 lora_module.show_information()
-lora_module.setup_and_join(mode, appkey, appeui)
+lora_module.setup_and_join_otaa(appkey, appeui)
 
-lora_module.send("MSGHEX", "01234567")
+lora_module.send_hex("01234567")

--- a/05-lora-tillo/e5.py
+++ b/05-lora-tillo/e5.py
@@ -5,46 +5,94 @@ class LoRaModule:
     def __init__(self, uart) -> None:
         self.uart = uart
 
-    def show_information(self):
-        self.send_and_recv("AT+CH")
-        self.send_and_recv("AT+MODE")
-        self.send_and_recv("AT+ID")
+    def show_information(self) -> None:
+        self.at_send("AT+CH")
+        self.at_send("AT+MODE")
+        self.at_send("AT+ID")
 
-    def set_mode(self, mode):
-        self.send_and_recv(f"AT+MODE={mode}")
+    def set_mode(self, mode) -> None:
+        if self.get_mode() != mode:
+            self.at_send(f"AT+MODE={mode}")
 
-    def setup_and_join(self, mode, appkey, appeui) -> bool:
-        self.set_mode(mode)
-        self.send_and_recv(f"AT+KEY=APPKEY, {appkey}")
-        self.send_and_recv(f"AT+ID=APPEUI, {appeui}")
+    def get_mode(self) -> str:
+        result = self.at_send("AT+MODE")
+        return result.split(":")[1].strip()
+
+    def get_ids(self) -> dict[str, str]:
+        response = self.at_send("AT+ID")
+        result = dict(DevAddr="", DevEui="", AppEui="")
+        for line in response.splitlines():
+            for key in result.keys():
+                if key in line:
+                    result[key] = line.split(",")[1].strip()
+
+        return result
+
+    def get_data_rate(self) -> str:
+        result = self.at_send("AT+DR")
+        return result.split(":")[1].strip()
+
+    def set_data_rate(self, data_rate) -> None:
+        self.at_send(f"AT+DR={data_rate}")
+
+    def set_appkey(self, appkey) -> None:
+        self.at_send(f"AT+KEY=APPKEY, {appkey}")
+
+    def set_appeui(self, appeui) -> None:
+        self.at_send(f"AT+ID=APPEUI, {appeui}")
+
+    def setup_and_join_otaa(self, appkey, appeui, force=False) -> bool:
+        if force or not self.join():
+            self.set_mode("LWOTAA")
+            self.set_appkey(appkey)
+            self.set_appeui(appeui)
+
         return self.join()
 
     def join(self) -> bool:
-        self.send_and_recv("AT+JOIN")
-        data = self.uart.readline()
-        while data is None:
-            time.sleep(0.2)
-            data = self.uart.readline()
-        data_string = "".join([chr(b) for b in data])
-        print(f"<-- {data_string}", end="")
-        if "failed" in data_string:
+        result = self.at_send("AT+JOIN", ["+JOIN: Done", "+JOIN: Joined already"])
+        if "Joined already" in result:
+            return True
+        if "failed" in result:
             return False
         else:
             return True
 
-    def send(self, mode, data):
-        self.send_and_recv(f"AT+{mode}={data}")
-        while data is None:
-            time.sleep(0.2)
-            data = self.uart.readline()
-        print(f"Sent: {data}")
+    def send(self, mode, data) -> str:
+        return self.at_send(f"AT+{mode}={data}", f"+{mode}: Done")
 
-    def send_and_recv(self, cmd):
+    def send_hex(self, data) -> str:
+        return self.send("MSGHEX", data)
+
+    def send_string(self, data) -> str:
+        return self.send("MSG", data)
+
+    def send_confirmed_hex(self, data) -> str:
+        return self.send("CMSGHEX", data)
+
+    def send_confirmed_string(self, data) -> str:
+        return self.send("CMSG", data)
+
+    def at_send(self, cmd, read_until_condition=None) -> str:
         print(f"--> {cmd}")
-        self.uart.write(bytes(cmd, "utf-8"))
-        data = self.uart.readline()
-        while data is not None:
+        self.uart.write(bytes(cmd + "\n", "utf-8"))
+        result = ""
+        while True:
+            data = self.uart.readline()
+            if data is None and not read_until_condition:
+                break
+            if data is None and read_until_condition:
+                time.sleep(0.1)
+                continue
+
             # convert bytearray to string
             data_string = "".join([chr(b) for b in data])
             print(f"<-- {data_string}", end="")
-            data = self.uart.readline()
+            result += data_string
+            if read_until_condition and data_string.strip() in read_until_condition:
+                break
+
+        return result
+
+    def factory_reset(self) -> None:
+        self.at_send("AT+FDEFAULT")

--- a/12-mz_badge_example/lorawan_simple.py
+++ b/12-mz_badge_example/lorawan_simple.py
@@ -1,9 +1,10 @@
 import mz_badge
-import os
+
+appkey = "YOUR_APP_KEY_HERE, eg. FFFFFFFFFFFFFFFFFF"
+appeui = "YOUR_APPEUI_HERE, eg. AAAAAAAAAAAA"
 
 lora_module = mz_badge.LoRaModule()
 lora_module.show_information()
 
-# lora_module.setup_and_join_otaa(os.getenv(mode), os.getenv(appkey), os.getenv(appeui))
-lora_module.join()
+lora_module.setup_and_join_otaa(appkey, appeui)
 lora_module.send_string("01234567")

--- a/lib/mz_badge.py
+++ b/lib/mz_badge.py
@@ -161,78 +161,96 @@ class LEDs:
 class LoRaModule:
 
     def __init__(self,uart=UART_LORA) -> None:
-        self.uart = uart
+       self.uart = uart
 
-    def show_information(self)-> None:
+    def show_information(self) -> None:
         self.at_send('AT+CH')
         self.at_send('AT+MODE')
         self.at_send('AT+ID')
 
-    def set_mode(self,mode)-> None:
-        self.at_send(f'AT+MODE={mode}')
+    def set_mode(self,mode) -> None:
+        if self.get_mode() != mode:
+            self.at_send(f'AT+MODE={mode}')
 
-    def setup_and_join_otaa(self,appkey, appeui) -> bool:
-        self.set_mode('OTAA')
+    def get_mode(self) -> str:
+        result = self.at_send('AT+MODE')
+        return result.split(':')[1].strip()
+
+    def get_ids(self) -> dict[str, str]:
+        response = self.at_send('AT+ID')
+        result = dict(DevAddr='', DevEui='', AppEui='')
+        for line in response.splitlines():
+            for key in result.keys():
+                if key in line:
+                    result[key] = line.split(',')[1].strip()
+
+        return result
+
+    def get_data_rate(self) -> str:
+        result = self.at_send('AT+DR')
+        return result.split(':')[1].strip()
+
+    def set_data_rate(self, data_rate) -> None:
+        self.at_send(f'AT+DR={data_rate}')
+
+    def set_appkey(self, appkey) -> None:
         self.at_send(f'AT+KEY=APPKEY, {appkey}')
+
+    def set_appeui(self, appeui) -> None:
         self.at_send(f'AT+ID=APPEUI, {appeui}')
+
+    def setup_and_join_otaa(self, appkey, appeui, force=False) -> bool:
+        if force or not self.join():
+            self.set_mode('LWOTAA')
+            self.set_appkey(appkey)
+            self.set_appeui(appeui)
+
         return self.join()
 
     def join(self) -> bool:
-        self.at_send('AT+JOIN=FORCE')
-        data = self.uart.readline() 
-        while data is None:
-            time.sleep(.2)
-            data = self.uart.readline()
-        data_string = ''.join([chr(b) for b in data])
-        print(f'<-- {data_string}', end="")
-        if "failed" in data_string:
+        result = self.at_send('AT+JOIN', ['+JOIN: Done', '+JOIN: Joined already'])
+        if 'Joined already' in result:
+            return True
+        if 'failed' in result:
             return False
         else:
             return True
 
-    def send(self, mode,data)-> None:
-        self.at_send(f'AT+{mode}={data}')
-        while data is  None:
-            time.sleep(.2)
-            data = self.uart.readline()
-        print(f'Sent: {data}')
+    def send(self, mode,data) -> str:
+        return self.at_send(f'AT+{mode}={data}', f'+{mode}: Done')
 
+    def send_hex(self,data) -> str:
+        return self.send('MSGHEX', data)
 
-    def send_hex(self,data)-> None:
-        self.at_send(f'AT+MSGHEX={data}')
-        while data is  None:
-            time.sleep(.2)
-            data = self.uart.readline()
-        print(f'Sent: {data}')
+    def send_string(self,data) -> str:
+        return self.send('MSG', data)
 
-    def send_string(self,data)-> None:
-        self.at_send(f'AT+MSG={data}')
-        while data is  None:
-            time.sleep(.2)
-            data = self.uart.readline()
-        print(f'Sent: {data}')
+    def send_confirmed_hex(self,data) -> str:
+        return self.send('CMSGHEX', data)
 
-    def send_confirmed_hex(self,data)-> None:
-        self.at_send(f'AT+CMSGHEX={data}')
-        while data is  None:
-            time.sleep(.2)
-            data = self.uart.readline()
-        print(f'Sent: {data}')
+    def send_confirmed_string(self,data) -> str:
+        return self.send('CMSG', data)
 
-    def send_confirmed_string(self,data)-> None:
-        self.at_send(f'AT+CMSG={data}')
-        while data is  None:
-            time.sleep(.2)
-            data = self.uart.readline()
-        print(f'Sent: {data}')
-
-    def at_send(self,cmd)-> None:
+    def at_send(self, cmd, read_until_condition=None) -> str:
         print(f'--> {cmd}')
-        self.uart.write(bytes(cmd+'\n','utf-8'))
+        self.uart.write(bytes(cmd + '\n', 'utf-8'))
+        result = ''
         while True:
-            byte_read = self.uart.readline() # read one line
-            if byte_read == None: # no more response
+            data = self.uart.readline()
+            if data is None and not read_until_condition:
                 break
+            if data is None and read_until_condition:
+                time.sleep(0.1)
+                continue
+
             # convert bytearray to string
-            data_string = ''.join([chr(b) for b in byte_read])
-            print(f'<-- {data_string}', end="")
+            data_string = ''.join([chr(b) for b in data])
+            print(f'<-- {data_string}', end='')
+            result += data_string
+            if read_until_condition and data_string.strip() in read_until_condition:
+                break
+
+        return result
+
+    def factory_reset(self) -> None:
+        self.at_send('AT+FDEFAULT')


### PR DESCRIPTION
The main reason for this was to use the fact the modem remembers joins so calling `setup_and_join` all the time would force a rejoin for no reason, but also wanted to properly check for results of the AT commands, so:

* `at_send` now can wait for a specific string condition to exit, instead of waiting for long timeouts
* `setup_and_join_otaa` will not join again if it's already joined, unless it's passed the `force=True` arg.
* all `send_*` methods return the results of the modem